### PR TITLE
Handle Device Disconnection Prior To Reset Callback Gracefully

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -377,8 +377,16 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         case .reset:
             switch mode {
             case .testAndConfirm:
-                let now = Date()
-                let timeSinceReset = now.timeIntervalSince(resetResponseTime!)
+                let timeSinceReset: TimeInterval
+                
+                if let resetResponseTime = resetResponseTime {
+                    let now = Date()
+                    timeSinceReset = now.timeIntervalSince(resetResponseTime)
+                } else {
+                    // Fallback if state changed prior to `resetResponseTime` is set
+                    timeSinceReset = 0
+                }
+                
                 let remainingTime = estimatedSwapTime - timeSinceReset
                 
                 if remainingTime > 0 {


### PR DESCRIPTION
Prerequisites:
The library is utilized with BT device.
McuMgrBleTransport reports BT device connection changes as appropriate.

Rationale:
When FirmwareUpgradeManager::reset() is called and the library transitions to `reset` state there is possible a situation when device connection state changes before `reset` callback received. E.g. if device goes disconnected without writing a value to smp characteristic, the call to FirmwareUpgradeManager::transport(transport:, didChangeStateTo:) would precede `reset` callback.

Current implementation relies on that `reset` callback is called first. Otherwise application triggers a runtime error as some variables remain not set.

Proposal:
Use optional binding to avoid triggering a runtime error. If `resetResponseTime` is not set for any reason then continue with predefined value.