### PR TITLE
DFU confirm slot 0 when slot 1 is confirmed

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -299,18 +299,11 @@
 			files = (
 			);
 			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/McuManager/McuManager.framework",
-				"${BUILT_PRODUCTS_DIR}/SwiftCBOR/SwiftCBOR.framework",
+				"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-			);
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/McuManager.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftCBOR.framework",
+				"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Example/Example/View Controllers/Scanner/ScannerViewController.swift
+++ b/Example/Example/View Controllers/Scanner/ScannerViewController.swift
@@ -78,7 +78,7 @@ class ScannerViewController: UITableViewController, CBCentralManagerDelegate, UI
             filterController.delegate = self
         case "connect":
             let controller = segue.destination as! BaseViewController
-            controller.peripheral = sender as! DiscoveredPeripheral
+            controller.peripheral = (sender as! DiscoveredPeripheral)
         default:
             break
         }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - McuManager (0.7):
+  - McuManager (0.7.0):
     - SwiftCBOR (= 0.3.0)
   - SwiftCBOR (0.3.0)
 
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  McuManager: 0c65d53799204dcab536edf75ce7a2181e982e08
+  McuManager: 321125f7744e71d128ee06fbca831b3145d4a8ee
   SwiftCBOR: 0b6b686bf24b77d06d35a2a6298713358c761bf8
 
 PODFILE CHECKSUM: 1753bed557e63b1f87b38c0a0b6c494113220627
 
-COCOAPODS: 1.6.0
+COCOAPODS: 1.7.1

--- a/McuManager.podspec
+++ b/McuManager.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'McuManager'
-  s.version = '0.7.0'
+  s.version = '0.7.1'
   s.license = { :type => "Apache 2.0", :file => 'LICENSE' }
   s.summary = 'A mobile management library for devices running Apache Mynewt or Zephyr'
   s.homepage = 'https://github.com/JuulLabs-OSS/mcumgr-ios'

--- a/McuManager.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/McuManager.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/Extensions/CBOR+McuManager.swift
+++ b/Source/Extensions/CBOR+McuManager.swift
@@ -13,7 +13,7 @@ internal extension CBOR {
         return "\"\(string)\""
     }
     
-    internal var description: String {
+    var description: String {
         switch self {
         case let .unsignedInt(l): return l.description
         case let .negativeInt(l): return l.description
@@ -33,7 +33,7 @@ internal extension CBOR {
         }
     }
     
-    internal var value : Any? {
+    var value : Any? {
         switch self {
         case let .unsignedInt(l): return Int(l)
         case let .negativeInt(l): return Int(l) * -1
@@ -53,7 +53,7 @@ internal extension CBOR {
         }
     }
     
-    internal static func toObjectMap<V: CBORMappable>(map: [CBOR:CBOR]?) throws -> [String:V]? {
+    static func toObjectMap<V: CBORMappable>(map: [CBOR:CBOR]?) throws -> [String:V]? {
         guard let map = map else {
             return nil
         }
@@ -67,7 +67,7 @@ internal extension CBOR {
         return objMap
     }
     
-    internal static func toMap<V>(map: [CBOR:CBOR]?) throws -> [String:V]? {
+    static func toMap<V>(map: [CBOR:CBOR]?) throws -> [String:V]? {
         guard let map = map else {
             return nil
         }
@@ -82,7 +82,7 @@ internal extension CBOR {
         return objMap
     }
     
-    internal static func toObjectArray<V: CBORMappable>(array: [CBOR]?) throws -> [V]? {
+    static func toObjectArray<V: CBORMappable>(array: [CBOR]?) throws -> [V]? {
         guard let array = array else {
             return nil
         }
@@ -94,7 +94,7 @@ internal extension CBOR {
         return objArray
     }
     
-    internal static func toArray<V>(array: [CBOR]?) throws -> [V]? {
+    static func toArray<V>(array: [CBOR]?) throws -> [V]? {
         guard let array = array else {
             return nil
         }

--- a/Source/Extensions/Data+McuManager.swift
+++ b/Source/Extensions/Data+McuManager.swift
@@ -11,22 +11,22 @@ internal extension Data {
     
     // MARK: - Convert data to and from types
     
-    internal init<T>(from value: T) {
+    init<T>(from value: T) {
         var value = value
         self.init(buffer: UnsafeBufferPointer(start: &value, count: 1))
     }
     
-    internal func to<T>(type: T.Type, offset: Int = 0) -> T {
+    func to<T>(type: T.Type, offset: Int = 0) -> T {
         return self[offset..<self.count].withUnsafeBytes { $0.pointee }
     }
     
-    internal func toReversed<T>(type: T.Type, offset: Int = 0) -> T {
+    func toReversed<T>(type: T.Type, offset: Int = 0) -> T {
         return Data(self.reversed()[offset..<self.count]).withUnsafeBytes { $0.pointee }
     }
     
     // MARK: - Hex Encoding
     
-    internal struct HexEncodingOptions: OptionSet {
+    struct HexEncodingOptions: OptionSet {
         public let rawValue: Int
         public static let upperCase = HexEncodingOptions(rawValue: 1 << 0)
         public static let space = HexEncodingOptions(rawValue: 1 << 1)
@@ -35,7 +35,7 @@ internal extension Data {
         }
     }
     
-    internal func hexEncodedString(options: HexEncodingOptions = []) -> String {
+    func hexEncodedString(options: HexEncodingOptions = []) -> String {
         var format = options.contains(.upperCase) ? "%02hhX" : "%02hhx"
         if options.contains(.space) {
             format.append(" ")
@@ -45,7 +45,7 @@ internal extension Data {
     
     // MARK: - Fragmentation
     
-    internal func fragment(size: Int) -> [Data] {
+    func fragment(size: Int) -> [Data] {
         return stride(from: 0, to: self.count, by: size).map {
             Data(self[$0..<Swift.min($0 + size, self.count)])
         }
@@ -53,7 +53,7 @@ internal extension Data {
     
     // MARK: - SHA 256
     
-    internal func sha256() -> [UInt8] {
+    func sha256() -> [UInt8] {
         var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
         withUnsafeBytes {
             _ = CC_SHA256($0, CC_LONG(count), &hash)

--- a/Source/Extensions/String+McuManager.swift
+++ b/Source/Extensions/String+McuManager.swift
@@ -8,7 +8,7 @@ import Foundation
 
 internal extension String {
     
-    internal func replaceFirst(of pattern:String, with replacement:String) -> String {
+    func replaceFirst(of pattern:String, with replacement:String) -> String {
         if let range = self.range(of: pattern) {
             return self.replacingCharacters(in: range, with: replacement)
         } else {
@@ -16,7 +16,7 @@ internal extension String {
         }
     }
     
-    internal func replaceLast(of pattern:String, with replacement:String) -> String {
+    func replaceLast(of pattern:String, with replacement:String) -> String {
         if let range = self.range(of: pattern, options: String.CompareOptions.backwards) {
             return self.replacingCharacters(in: range, with: replacement)
         } else {


### PR DESCRIPTION
Previously, in the validate state, the device would be reset if the image in slot 1 was confirmed. Resetting the device takes time and is probably the most error prone part of the upgrade, so we should avoid it at all costs. 

This PR will confirm the image in slot 0 if the image in slot 1 is confirmed, then re-validates the image state.

This PR also removes a bunch of compiler warnings.