### PR TITLE
Adjusted when transfer variables are reset to avoid a later crash when accessing values

### DIFF
--- a/Source/Managers/FileSystemManager.swift
+++ b/Source/Managers/FileSystemManager.swift
@@ -393,8 +393,8 @@ public class FileSystemManager: McuManager {
             // Check if the upload has completed.
             if self.offset == self.fileData!.count {
                 Log.d(FileSystemManager.TAG, msg: "Download finished!")
-                self.resetTransfer()
                 self.downloadDelegate?.download(of: self.fileName!, didFinish: self.fileData!)
+                self.resetTransfer()
                 self.downloadDelegate = nil
                 // Release cyclic reference.
                 self.cyclicReferenceHolder = nil


### PR DESCRIPTION
The function `resetTransfer()` sets both `fileName` and `fileData` to nil, resulting in the crash on the following line. Doing the reset after notifying the delegate fixes the issue.
