### PR TITLE
Added an API to access Transport and Firmware Upgrade Logs

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - McuManager (0.8.0):
+  - McuManager (0.8.1):
     - SwiftCBOR (= 0.4.3)
   - SwiftCBOR (0.4.3)
 
@@ -7,7 +7,7 @@ DEPENDENCIES:
   - McuManager (from `../`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - SwiftCBOR
 
 EXTERNAL SOURCES:
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  McuManager: 7c5f30fb540dbf62676eff816860a7f8d6fd36e6
+  McuManager: 1259e76b68c1535a77b57373af88fa9656c90e76
   SwiftCBOR: c7d740966575e0fd5d971466de2b6776db3f10c3
 
 PODFILE CHECKSUM: 1753bed557e63b1f87b38c0a0b6c494113220627
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.9.1

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ McuManager firmware upgrades can actually be performed in few different ways. Th
 
 The `FirmwareUpgradeManager` contains an additional state, `validate`, which precedes the upload. The `validate` state checks the current image state of the device in an attempt to bypass certain states of the firmware upgrade. For example, if the image to upgrade to already exists in slot 1 on the device, the `FirmwareUpgradeManager` will skip `upload` and move directly to `test` (or `confirm` if `.confirmOnly` mode has been set) from `validate`. If the uploaded image is already active, and confirmed in slot 0, the upgrade will succeed immediately. In short, the `validate` state makes it easy to reattempt an upgrade without needing to re-upload the image or manually determine where to start.
 
+### Log Access
+
+`McuMgrLogDelegate` is the protocol used as a callback to give you logs regarding the state of the firmware upgrade mechanism, including device connection, service discovery and so on. You can use the `@logDelegate` property from `McuMgrBleTransport` to get access to the BLE Transport logs, and as for the firmware upgrade process itself, `FirmwareUpgradeManager`'s delegate type, `FirmwareUpgradeDelegate`, extends `McuMgrLogDelegate`, so the same callback site applies to both.
+
 # Developing for McuManager
 
 Clone the repository, install pods.

--- a/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/Source/Bluetooth/McuMgrBleTransport.swift
@@ -132,6 +132,8 @@ public class McuMgrBleTransport: NSObject {
         return peripheral?.name
     }
     
+    public weak var logDelegate: McuMgrLogDelegate?
+    
     public private(set) var identifier: UUID
 
     private func notifyPeripheralDelegate() {
@@ -173,7 +175,7 @@ extension McuMgrBleTransport: McuMgrTransport {
     
     public func close() {
         if let peripheral = peripheral, peripheral.state == .connected || peripheral.state == .connecting {
-            Log.v(TAG, msg: "Cancelling connection...")
+            log(.verbose, msg: "Cancelling connection...")
             state = .disconnecting
             centralManager.cancelPeripheralConnection(peripheral)
         }
@@ -207,7 +209,7 @@ extension McuMgrBleTransport: McuMgrTransport {
     private func _send<T: McuMgrResponse>(data: Data, callback: @escaping McuMgrCallback<T>) -> Bool {
         // Is Bluetooth operational?
         if centralManager.state == .poweredOff || centralManager.state == .unsupported {
-            Log.w(TAG, msg: "Central Manager powered off")
+            log(.warn, msg: "Central Manager powered off")
             fail(error: McuMgrBleTransportError.centralManagerPoweredOff, callback: callback)
             return false
         }
@@ -229,21 +231,21 @@ extension McuMgrBleTransport: McuMgrTransport {
             // Check for timeout, failure, or success.
             switch result {
             case .timeout:
-                Log.w(TAG, msg: "Central Manager timed out")
+                log(.warn, msg: "Central Manager timed out")
                 fail(error: McuMgrTransportError.connectionTimeout, callback: callback)
                 return false
             case let .error(error):
-                Log.w(TAG, msg: "Central Manager failed to start: \(error)")
+                log(.warn, msg: "Central Manager failed to start: \(error)")
                 fail(error: error, callback: callback)
                 return false
             case .success:
                 guard let target = self.peripheral else {
-                    Log.w(TAG, msg: "Central Manager timed out")
+                    log(.warn, msg: "Central Manager timed out")
                     fail(error: McuMgrTransportError.connectionTimeout, callback: callback)
                     return false
                 }
                 // continue
-                Log.v(TAG, msg: "Central Manager  ready")
+                log(.verbose, msg: "Central Manager  ready")
                 targetPeripheral = target
             }
         }
@@ -259,8 +261,8 @@ extension McuMgrBleTransport: McuMgrTransport {
                 // characteristic has not been set, start by performing service
                 // discovery. Once the characteristic's notification is enabled,
                 // the semaphore will be signalled and the request can be sent.
-                Log.i(TAG, msg: "Peripheral already connected")
-                Log.v(TAG, msg: "Discovering services...")
+                log(.info, msg: "Peripheral already connected")
+                log(.verbose, msg: "Discovering services...")
                 state = .connecting
                 targetPeripheral.delegate = self
                 targetPeripheral.discoverServices([McuMgrBleTransport.SMP_SERVICE])
@@ -269,19 +271,19 @@ extension McuMgrBleTransport: McuMgrTransport {
                 // connecting to the device. Once the characteristic's
                 // notification is enabled, the semaphore will be signalled and
                 // the request can be sent.
-                Log.v(TAG, msg: "Connecting...")
+                log(.verbose, msg: "Connecting...")
                 state = .connecting
                 centralManager.connect(targetPeripheral)
             case .connecting:
-                Log.i(TAG, msg: "Device is connecting. Wait...")
+                log(.info, msg: "Device is connecting. Wait...")
                 state = .connecting
                 // Do nothing. It will switch to .connected or .disconnected.
             case .disconnecting:
-                Log.i(TAG, msg: "Device is disconnecting. Wait...")
+                log(.info, msg: "Device is disconnecting. Wait...")
                 // If the peripheral's connection state is transitioning, wait
                 // and retry
                 sleep(10)
-                Log.v(TAG, msg: "Retry send request...")
+                log(.verbose, msg: "Retry send request...")
                 return true
             }
             
@@ -292,23 +294,23 @@ extension McuMgrBleTransport: McuMgrTransport {
             switch result {
             case .timeout:
                 state = .disconnected
-                Log.w(TAG, msg: "Connection timed out")
+                log(.warn, msg: "Connection timed out")
                 fail(error: McuMgrTransportError.connectionTimeout, callback: callback)
                 return false
             case let .error(error):
                 state = .disconnected
-                Log.w(TAG, msg: "Connection failed: \(error)")
+                log(.warn, msg: "Connection failed: \(error)")
                 fail(error: error, callback: callback)
                 return false
             case .success:
-                Log.v(TAG, msg: "Device ready")
+                log(.verbose, msg: "Device ready")
                 // continue
             }
         }
         
         // Make sure the SMP characteristic is not nil.
         guard let smpCharacteristic = smpCharacteristic else {
-            Log.e(TAG, msg: "Missing the SMP characteristic after connection setup.")
+            log(.error, msg: "Missing the SMP characteristic after connection setup.")
             fail(error: McuMgrBleTransportError.missingCharacteristic, callback: callback)
             return false
         }
@@ -319,7 +321,7 @@ extension McuMgrBleTransport: McuMgrTransport {
         // Check that data length does not exceed the mtu.
         let mtu = targetPeripheral.maximumWriteValueLength(for: .withoutResponse)
         if (data.count > mtu) {
-            Log.e(TAG, msg: "Length of data to send exceeds MTU")
+            log(.error, msg: "Length of data to send exceeds MTU")
             // Fail with an insufficient MTU error
             fail(error: McuMgrTransportError.insufficientMtu(mtu: mtu) as Error, callback: callback)
             return false
@@ -334,10 +336,10 @@ extension McuMgrBleTransport: McuMgrTransport {
         
         switch result {
         case .timeout:
-            Log.e(TAG, msg: "Request timed out")
+            log(.error, msg: "Request timed out")
             fail(error: McuMgrTransportError.sendTimeout, callback: callback)
         case .error(let error):
-            Log.e(TAG, msg: "Request failed: \(error)")
+            log(.error, msg: "Request failed: \(error)")
             fail(error: error, callback: callback)
         case .success:
             do {
@@ -368,6 +370,11 @@ extension McuMgrBleTransport: McuMgrTransport {
             callback(nil, error)
         }
     }
+    
+    private func log(_ level: Log.Level, msg: String) {
+        Log.log(level, tag: TAG, msg: msg)
+        logDelegate?.log(msg)
+    }
 }
 
 //******************************************************************************
@@ -395,9 +402,9 @@ extension McuMgrBleTransport: CBCentralManagerDelegate {
         guard self.identifier == peripheral.identifier else {
             return
         }
-        Log.i(TAG, msg: "Peripheral connected")
+        log(.info, msg: "Peripheral connected")
         state = .initializing
-        Log.v(TAG, msg: "Discovering services...")
+        log(.verbose, msg: "Discovering services...")
         peripheral.delegate = self
         peripheral.discoverServices([McuMgrBleTransport.SMP_SERVICE])
     }
@@ -406,7 +413,7 @@ extension McuMgrBleTransport: CBCentralManagerDelegate {
         guard self.identifier == peripheral.identifier else {
             return
         }
-        Log.i(TAG, msg: "Peripheral disconnected")
+        log(.info, msg: "Peripheral disconnected")
         peripheral.delegate = nil
         smpCharacteristic = nil
         lock.open(McuMgrTransportError.disconnected)
@@ -418,7 +425,7 @@ extension McuMgrBleTransport: CBCentralManagerDelegate {
         guard self.identifier == peripheral.identifier else {
             return
         }
-        Log.w(TAG, msg: "Peripheral failed to connect")
+        log(.warn, msg: "Peripheral failed to connect")
         lock.open(McuMgrTransportError.connectionFailed)
     }
 }
@@ -436,7 +443,7 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
             return
         }
         
-        Log.i(TAG, msg: "Services discovered: \(peripheral.services ?? [])")
+        log(.info, msg: "Services discovered: \(peripheral.services ?? [])")
         
         // Get peripheral's services.
         guard let services = peripheral.services else {
@@ -446,7 +453,7 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
         // Find the service matching the SMP service UUID.
         for service in services {
             if service.uuid == McuMgrBleTransport.SMP_SERVICE {
-                Log.v(TAG, msg: "Discovering characteristics...")
+                log(.verbose, msg: "Discovering characteristics...")
                 peripheral.discoverCharacteristics([McuMgrBleTransport.SMP_CHARACTERISTIC], for: service)
                 return
             }
@@ -461,7 +468,7 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
             return
         }
         
-        Log.i(TAG, msg: "Characteristics discovered: \(service.characteristics ?? [])")
+        log(.info, msg: "Characteristics discovered: \(service.characteristics ?? [])")
         
         // Get service's characteristics.
         guard let characteristics = service.characteristics else {
@@ -473,7 +480,7 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
             if characteristic.uuid == McuMgrBleTransport.SMP_CHARACTERISTIC {
                 // Set the characteristic notification if available.
                 if characteristic.properties.contains(.notify) {
-                    Log.v(TAG, msg: "Enabling notifications...")
+                    log(.verbose, msg: "Enabling notifications...")
                     peripheral.setNotifyValue(true, for: characteristic)
                 } else {
                     lock.open(McuMgrBleTransportError.missingNotifyProperty)
@@ -494,7 +501,7 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
             return
         }
         
-        Log.i(TAG, msg: "Notifications enabled")
+        log(.info, msg: "Notifications enabled")
         
         // Set the SMP characteristic.
         smpCharacteristic = characteristic

--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -54,7 +54,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
     public func start(data: Data) throws {
         objc_sync_enter(self)
         if state != .none {
-            Log.w(TAG, msg: "Firmware upgrade is already in progress")
+            log(.warn, msg: "Firmware upgrade is already in progress")
             return
         }
         imageData = data
@@ -80,7 +80,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
     public func pause() {
         objc_sync_enter(self)
         if state.isInProgress() && !paused {
-            Log.v(TAG, msg: "Pausing upgrade...")
+            log(.verbose, msg: "Pausing upgrade...")
             paused = true
             if state == .upload {
                 imageManager.pauseUpload()
@@ -189,7 +189,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
     
     private func fail(error: Error) {
         objc_sync_enter(self)
-        Log.e(TAG, error: error)
+        log(.error, msg: error.localizedDescription)
         let tmp = state
         state = .none
         paused = false
@@ -221,7 +221,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
     }
     
     //**************************************************************************
-    // MARK: McuMgrCallbacks
+    // MARK: - McuMgrCallbacks
     //**************************************************************************
     
     /// Callback for the VALIDATE state.
@@ -243,7 +243,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
             self.fail(error: FirmwareUpgradeError.unknown("Validation response is nil!"))
             return
         }
-        Log.v(self.TAG, msg: "Validation response: \(response)")
+        self.log(.verbose, msg: "Validation response: \(response)")
         // Check for McuMgrReturnCode error.
         if !response.isSuccess() {
             self.fail(error: FirmwareUpgradeError.mcuMgrReturnCodeError(response.returnCode))
@@ -372,7 +372,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
             self.fail(error: FirmwareUpgradeError.unknown("Test response is nil!"))
             return
         }
-        Log.v(self.TAG, msg: "Test response: \(response)")
+        self.log(.verbose, msg: "Test response: \(response)")
         // Check for McuMgrReturnCode error.
         if !response.isSuccess() {
             self.fail(error: FirmwareUpgradeError.mcuMgrReturnCodeError(response.returnCode))
@@ -422,7 +422,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
             return
         }
         self.resetResponseTime = Date()
-        Log.i(self.TAG, msg: "Reset request sent. Waiting for reset...")
+        self.log(.info, msg: "Reset request sent. Waiting for reset...")
     }
     
     public func transport(_ transport: McuMgrTransport, didChangeStateTo state: McuMgrTransportState) {
@@ -431,7 +431,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         guard state == .disconnected else {
             return
         }
-        Log.i(self.TAG, msg: "Device has disconnected (reset). Reconnecting...")
+        self.log(.info, msg: "Device has disconnected (reset). Reconnecting...")
         let timeSinceReset: TimeInterval
         if let resetResponseTime = resetResponseTime {
             let now = Date()
@@ -459,13 +459,13 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
             }
             switch result {
             case .connected:
-                Log.i(self.TAG, msg: "Reconnect successful.")
+                self.log(.info, msg: "Reconnect successful.")
                 break
             case .deferred:
-                Log.i(self.TAG, msg: "Reconnect deferred.")
+                self.log(.info, msg: "Reconnect deferred.")
                 break
             case .failed(let error):
-                Log.e(self.TAG, msg: "Reconnect failed. \(error)")
+                self.log(.error, msg: "Reconnect failed. \(error)")
                 self.fail(error: error)
                 return
             }
@@ -487,6 +487,11 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         }
     }
     
+    private func log(_ level: Log.Level, msg: String) {
+        Log.log(level, tag: TAG, msg: msg)
+        delegate?.log(msg)
+    }
+    
     /// Callback for the CONFIRM state.
     ///
     /// This callback will fail the upload on error or move to the next state on
@@ -506,7 +511,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
             self.fail(error: FirmwareUpgradeError.unknown("Confirm response is nil!"))
             return
         }
-        Log.v(self.TAG, msg: "Confirm response: \(response)")
+        self.log(.verbose, msg: "Confirm response: \(response)")
         // Check for McuMgrReturnCode error.
         if !response.isSuccess() {
             self.fail(error: FirmwareUpgradeError.mcuMgrReturnCodeError(response.returnCode))
@@ -553,7 +558,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
 }
 
 //******************************************************************************
-// MARK: ImageUploadDelegate
+// MARK: - ImageUploadDelegate
 //******************************************************************************
 
 extension FirmwareUpgradeManager: ImageUploadDelegate {
@@ -586,7 +591,7 @@ extension FirmwareUpgradeManager: ImageUploadDelegate {
 }
 
 //******************************************************************************
-// MARK: FirmwareUpgradeError
+// MARK: - FirmwareUpgradeError
 //******************************************************************************
 
 public enum FirmwareUpgradeError: Error {
@@ -613,7 +618,7 @@ extension FirmwareUpgradeError: CustomStringConvertible {
 }
 
 //******************************************************************************
-// MARK: FirmwareUpgradeState
+// MARK: - FirmwareUpgradeState
 //******************************************************************************
 
 public enum FirmwareUpgradeState {
@@ -626,7 +631,7 @@ public enum FirmwareUpgradeState {
 }
 
 //******************************************************************************
-// MARK: FirmwareUpgradeMode
+// MARK: - FirmwareUpgradeMode
 //******************************************************************************
 
 public enum FirmwareUpgradeMode {
@@ -658,11 +663,11 @@ public enum FirmwareUpgradeMode {
 }
 
 //******************************************************************************
-// MARK: FirmwareUpgradeDelegate
+// MARK: - FirmwareUpgradeDelegate
 //******************************************************************************
 
 /// Callbacks for firmware upgrades started using FirmwareUpgradeManager.
-public protocol FirmwareUpgradeDelegate : class {
+public protocol FirmwareUpgradeDelegate : McuMgrLogDelegate {
     
     /// Called when the upgrade has started.
     ///

--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -54,7 +54,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
     public func start(data: Data) throws {
         objc_sync_enter(self)
         if state != .none {
-            log(.warn, msg: "Firmware upgrade is already in progress")
+            log(msg: "Firmware upgrade is already in progress", atLevel: .warn)
             return
         }
         imageData = data
@@ -80,7 +80,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
     public func pause() {
         objc_sync_enter(self)
         if state.isInProgress() && !paused {
-            log(.verbose, msg: "Pausing upgrade...")
+            log(msg: "Pausing upgrade...", atLevel: .verbose)
             paused = true
             if state == .upload {
                 imageManager.pauseUpload()
@@ -189,7 +189,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
     
     private func fail(error: Error) {
         objc_sync_enter(self)
-        log(.error, msg: error.localizedDescription)
+        log(msg: error.localizedDescription, atLevel: .error)
         let tmp = state
         state = .none
         paused = false
@@ -243,7 +243,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
             self.fail(error: FirmwareUpgradeError.unknown("Validation response is nil!"))
             return
         }
-        self.log(.verbose, msg: "Validation response: \(response)")
+        self.log(msg: "Validation response: \(response)", atLevel: .verbose)
         // Check for McuMgrReturnCode error.
         if !response.isSuccess() {
             self.fail(error: FirmwareUpgradeError.mcuMgrReturnCodeError(response.returnCode))
@@ -372,7 +372,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
             self.fail(error: FirmwareUpgradeError.unknown("Test response is nil!"))
             return
         }
-        self.log(.verbose, msg: "Test response: \(response)")
+        self.log(msg: "Test response: \(response)", atLevel: .verbose)
         // Check for McuMgrReturnCode error.
         if !response.isSuccess() {
             self.fail(error: FirmwareUpgradeError.mcuMgrReturnCodeError(response.returnCode))
@@ -422,7 +422,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
             return
         }
         self.resetResponseTime = Date()
-        self.log(.info, msg: "Reset request sent. Waiting for reset...")
+        self.log(msg: "Reset request sent. Waiting for reset...", atLevel: .info)
     }
     
     public func transport(_ transport: McuMgrTransport, didChangeStateTo state: McuMgrTransportState) {
@@ -431,7 +431,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         guard state == .disconnected else {
             return
         }
-        self.log(.info, msg: "Device has disconnected (reset). Reconnecting...")
+        self.log(msg: "Device has disconnected (reset). Reconnecting...", atLevel: .info)
         let timeSinceReset: TimeInterval
         if let resetResponseTime = resetResponseTime {
             let now = Date()
@@ -459,13 +459,13 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
             }
             switch result {
             case .connected:
-                self.log(.info, msg: "Reconnect successful.")
+                self.log(msg: "Reconnect successful.", atLevel: .info)
                 break
             case .deferred:
-                self.log(.info, msg: "Reconnect deferred.")
+                self.log(msg: "Reconnect deferred.", atLevel: .info)
                 break
             case .failed(let error):
-                self.log(.error, msg: "Reconnect failed. \(error)")
+                self.log(msg: "Reconnect failed. \(error)", atLevel: .error)
                 self.fail(error: error)
                 return
             }
@@ -487,9 +487,9 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         }
     }
     
-    private func log(_ level: Log.Level, msg: String) {
+    private func log(msg: String, atLevel level: Log.Level) {
         Log.log(level, tag: TAG, msg: msg)
-        delegate?.log(msg)
+        delegate?.log(msg, atLevel: level)
     }
     
     /// Callback for the CONFIRM state.
@@ -511,7 +511,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
             self.fail(error: FirmwareUpgradeError.unknown("Confirm response is nil!"))
             return
         }
-        self.log(.verbose, msg: "Confirm response: \(response)")
+        self.log(msg: "Confirm response: \(response)", atLevel: .verbose)
         // Check for McuMgrReturnCode error.
         if !response.isSuccess() {
             self.fail(error: FirmwareUpgradeError.mcuMgrReturnCodeError(response.returnCode))

--- a/Source/McuMgrLogDelegate.swift
+++ b/Source/McuMgrLogDelegate.swift
@@ -1,0 +1,16 @@
+//
+//  McuMgrLogDelegate.swift
+//  McuManager
+//
+//  Created by Dinesh Harjani on 16/03/2020.
+//
+
+import Foundation
+
+public protocol McuMgrLogDelegate: class {
+    
+    /// Provides the delegate with content intended to be logged.
+    ///
+    /// - parameter msg: The text to log.
+    func log(_ msg: String)
+}

--- a/Source/McuMgrLogDelegate.swift
+++ b/Source/McuMgrLogDelegate.swift
@@ -1,9 +1,8 @@
-//
-//  McuMgrLogDelegate.swift
-//  McuManager
-//
-//  Created by Dinesh Harjani on 16/03/2020.
-//
+/*
+ * Copyright (c) 2017-2018 Runtime Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 import Foundation
 
@@ -12,5 +11,6 @@ public protocol McuMgrLogDelegate: class {
     /// Provides the delegate with content intended to be logged.
     ///
     /// - parameter msg: The text to log.
-    func log(_ msg: String)
+    /// - parameter level: The priority of the text being logged.
+    func log(_ msg: String, atLevel level: Log.Level)
 }

--- a/Source/Utils/Log.swift
+++ b/Source/Utils/Log.swift
@@ -6,15 +6,9 @@
 
 import Foundation
 
-class Log {
-    
-    enum Level: String {
-        case verbose = "V/"
-        case debug = "D/"
-        case info = "I/"
-        case warn = "W/"
-        case error = "E/"
-    }
+// MARK: - Log
+
+public class Log {
     
     static func log(_ level: Level, tag: String, msg: String) {
         print("\(timestamp()) \(level.rawValue)\(tag): \(msg)")
@@ -48,5 +42,18 @@ class Log {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm:ss.SSS"
         return formatter.string(from: Date())
+    }
+}
+
+// MARK: - Log.Level
+
+extension Log {
+    
+    public enum Level: String {
+        case verbose = "V/"
+        case debug = "D/"
+        case info = "I/"
+        case warn = "W/"
+        case error = "E/"
     }
 }


### PR DESCRIPTION
A new delegate, McuMgrLogDelegate, has been defined, which FirmwareUpgradeManagerDelegate extends, meaning the new protocol is reused to offer a better API for our users.
README file has also been updated to inform library users of this functionality.