### PR TITLE
Fixed handling error when testing image generates an error

### DIFF
--- a/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
+++ b/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
@@ -61,10 +61,10 @@ class ImagesViewController: UIViewController , McuMgrViewController{
         let oldRect = message.sizeThatFits(bounds)
         
         if let response = response {
-            var info = "Split status: \(response.splitStatus ?? 0)"
-            if let images = response.images {
-                var i = 0
-                for image in images {
+            if response.isSuccess(), let images = response.images {
+                var info = "Split status: \(response.splitStatus ?? 0)"
+                
+                for (i, image) in images.enumerated() {
                     info += "\nSlot \(i)\n" +
                         "• Version: \(image.version!)\n" +
                         "• Hash: \(Data(image.hash).hexEncodedString(options: .upperCase))\n" +
@@ -89,7 +89,6 @@ class ImagesViewController: UIViewController , McuMgrViewController{
                     } else {
                         info = String(info.dropLast(2))
                     }
-                    i += 1
                     
                     if !image.confirmed {
                         imageHash = image.hash
@@ -99,13 +98,22 @@ class ImagesViewController: UIViewController , McuMgrViewController{
                 testAction.isEnabled = images.count > 1 && !images[1].pending
                 confirmAction.isEnabled = images.count > 1 && !images[1].permanent
                 eraseAction.isEnabled = images.count > 1 && !images[1].confirmed
+                
+                message.text = info
+                message.textColor = .primary
+            } else { // not a success
+                readAction.isEnabled = true
+                message.textColor = .systemRed
+                message.text = "Device returned error: \(response.returnCode)"
             }
-            message.text = info
-            message.textColor = .primary
-        } else {
+        } else { // no response
             readAction.isEnabled = true
             message.textColor = .systemRed
-            message.text = "\(error!)"
+            if let error = error {
+                message.text = "\(error)"
+            } else {
+                message.text = "Empty response"
+            }
         }
         let newRect = message.sizeThatFits(bounds)
         let diff = newRect.height - oldRect.height

--- a/Source/McuMgrResponse.swift
+++ b/Source/McuMgrResponse.swift
@@ -41,7 +41,7 @@ public class McuMgrResponse: CBORMappable {
     
     /// The repsponse's return code obtained from the payload. If no return code
     /// is explicitly stated, OK (0) is assumed.
-    public var returnCode: McuMgrReturnCode! = .ok
+    public var returnCode: McuMgrReturnCode = .ok
     
     /// The CoAP Response code for CoAP based transport schemes. For non-CoAP
     /// transport schemes this value will always be 0
@@ -134,7 +134,7 @@ public class McuMgrResponse: CBORMappable {
         response.header = header
         response.scheme = scheme
         response.rawData = bytes
-        response.returnCode = McuMgrReturnCode(rawValue: response.rc)
+        response.returnCode = McuMgrReturnCode(rawValue: response.rc) ?? .unrecognized
         response.coapCode = coapCode
         
         return response


### PR DESCRIPTION
There is a bug in the sample app, when the app fails to restore buttons states when any of Images request fails.
Steps to reproduce:
1. Using Advanced Images screen, flash the same image, as it's in slot0. It is possible when using only ImageManager, as it doesn't do any validation.
2. Click Test.
3. The device responds with rc = Unknown (1) 
4. None of the buttons gets enabled again until disconnected.

This PR fixes this issue. It also removes ! from the `returnCode` property in the response, as it's initially set to OK.