### PR TITLE
Migration to Swift 5.2

### DIFF
--- a/McuManager.podspec
+++ b/McuManager.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/JuulLabs-OSS/mcumgr-ios'
   s.authors = { 'Brian Giori' => 'brian.giori@juul.com' }
   s.source = { :git => 'https://github.com/JuulLabs-OSS/mcumgr-ios.git', :tag => "#{s.version}" }
-  s.swift_version = '4.2'
+  s.swift_versions = ['4.2', '5.0', '5.1', '5.2']
 
   s.ios.deployment_target = '9.0'
 

--- a/Source/Extensions/Data+McuManager.swift
+++ b/Source/Extensions/Data+McuManager.swift
@@ -13,7 +13,9 @@ internal extension Data {
     
     init<T>(from value: T) {
         var value = value
-        self.init(buffer: UnsafeBufferPointer(start: &value, count: 1))
+        self = withUnsafePointer(to: &value) { (pointer) -> Data in
+            Data(buffer: UnsafeBufferPointer(start: pointer, count: 1))
+        }
     }
     
     func read<T: FixedWidthInteger>(offset: Int = 0) -> T {


### PR DESCRIPTION
This PR modifies the code to be compatible with Swift 5.2 with no warnings.
Also, the Podspec now specifies compatible swift versions.