### PR TITLE
Option to specify FS mount point

### DIFF
--- a/Example/Example/View Controllers/Manager/FileDownloadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FileDownloadViewController.swift
@@ -45,20 +45,21 @@ class FileDownloadViewController: UIViewController, McuMgrViewController {
         }
     }
     
-    private var fsManager: FileSystemManager!
     var transporter: McuMgrTransport! {
         didSet {
             fsManager = FileSystemManager(transporter: transporter)
             fsManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
         }
     }
-    var partition: String = "nffs" {
-        didSet {
-            refreshSource()
-        }
-    }
     var height: CGFloat = 80
     var tableView: UITableView!
+    
+    private var fsManager: FileSystemManager!
+    private var partition: String {
+        return UserDefaults.standard
+            .string(forKey: FilesController.partitionKey)
+            ?? FilesController.defaultPartition
+    }
 
     private func refreshSource() {
         source.text = "/\(partition)/\(file.text!)"
@@ -67,6 +68,10 @@ class FileDownloadViewController: UIViewController, McuMgrViewController {
     override func viewDidLoad() {
         let recents = UserDefaults.standard.array(forKey: recentsKey)
         actionOpenRecents.isEnabled = recents != nil
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        refreshSource()
     }
     
     func addRecent(_ name: String) {

--- a/Example/Example/View Controllers/Manager/FileUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FileUploadViewController.swift
@@ -54,7 +54,6 @@ class FileUploadViewController: UIViewController, McuMgrViewController {
         fsManager.cancelTransfer()
     }
     
-    private var fsManager: FileSystemManager!
     var transporter: McuMgrTransport! {
         didSet {
             fsManager = FileSystemManager(transporter: transporter)
@@ -62,15 +61,22 @@ class FileUploadViewController: UIViewController, McuMgrViewController {
         }
     }
     
+    private var fsManager: FileSystemManager!
     private var fileData: Data?
-    var partition: String = "nffs" {
-        didSet {
-            refreshDestination()
-        }
+    private var partition: String {
+        return UserDefaults.standard
+            .string(forKey: FilesController.partitionKey)
+            ?? FilesController.defaultPartition
     }
     
     private func refreshDestination() {
-        destination.text = "/\(partition)/\(fileName.text!)"
+        if let _ = fileData {
+            destination.text = "/\(partition)/\(fileName.text!)"
+        }
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        refreshDestination()
     }
 }
 
@@ -119,12 +125,14 @@ extension FileUploadViewController: FileUploadDelegate {
 // MARK: - Document Picker
 extension FileUploadViewController: UIDocumentMenuDelegate, UIDocumentPickerDelegate {
     
-    func documentMenu(_ documentMenu: UIDocumentMenuViewController, didPickDocumentPicker documentPicker: UIDocumentPickerViewController) {
+    func documentMenu(_ documentMenu: UIDocumentMenuViewController,
+                      didPickDocumentPicker documentPicker: UIDocumentPickerViewController) {
         documentPicker.delegate = self
         present(documentPicker, animated: true, completion: nil)
     }
     
-    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentAt url: URL) {
+    func documentPicker(_ controller: UIDocumentPickerViewController,
+                        didPickDocumentAt url: URL) {
         if let data = dataFrom(url: url) {
             self.fileData = data
             

--- a/Example/Example/View Controllers/Manager/FilesController.swift
+++ b/Example/Example/View Controllers/Manager/FilesController.swift
@@ -8,15 +8,24 @@ import UIKit
 import McuManager
 
 class FilesController: UITableViewController {
+    static let partitionKey = "partition"
+    static let defaultPartition = "nffs"
+    
     @IBOutlet weak var connectionStatus: ConnectionStateLabel!
     
     var fileDownloadViewController: FileDownloadViewController!
     
     override func viewDidAppear(_ animated: Bool) {
+        showPartitionControl()
+        
         // Set the connection status label as transport delegate.
         let baseController = parent as! BaseViewController
         let bleTransporter = baseController.transporter as? McuMgrBleTransport
         bleTransporter?.delegate = connectionStatus
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        tabBarController!.navigationItem.rightBarButtonItem = nil
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -38,5 +47,44 @@ class FilesController: UITableViewController {
         }
         return super.tableView(tableView, heightForRowAt: indexPath)
     }
-
+    
+    // MARK: Partition settings
+    private func showPartitionControl() {
+        let navItem = tabBarController!.navigationItem
+        navItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .edit,
+                                                     target: self,
+                                                     action: #selector(presentPartitionSettings))
+    }
+    
+    @objc func presentPartitionSettings() {
+        let alert = UIAlertController(title: "Settings",
+                                      message: "Specify the mount point,\ne.g. \"nffs\" or \"lfs\":",
+                                      preferredStyle: .alert)
+        alert.addTextField { field in
+            field.placeholder = "Partition"
+            field.autocorrectionType = .no
+            field.autocapitalizationType = .none
+            field.returnKeyType = .done
+            field.clearButtonMode = .always
+            field.text = UserDefaults.standard
+                .string(forKey: FilesController.partitionKey)
+                ?? FilesController.defaultPartition
+        }
+        alert.addAction(UIAlertAction(title: "OK", style: .default) { _ in
+            let newName = alert.textFields![0].text
+            if let newName = newName, !newName.isEmpty {
+                UserDefaults.standard.set(alert.textFields![0].text,
+                                          forKey: FilesController.partitionKey)
+                self.tableView.reloadData()
+            }
+        })
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Default (\(FilesController.defaultPartition))",
+                                      style: .default) { _ in
+            UserDefaults.standard.set(FilesController.defaultPartition,
+                                      forKey: FilesController.partitionKey)
+            self.tableView.reloadData()
+        })
+        present(alert, animated: true)
+    }
 }


### PR DESCRIPTION
This PR adds the same feature as there is in the Android sample app: option to set the mount point. By default the mount point is set to "nffs", but can be changed to "lfs" or any other.

This partially fixes #40.