### PR TITLE
Displaying errors improved

### DIFF
--- a/Example/Example/View Controllers/Manager/DeviceController.swift
+++ b/Example/Example/View Controllers/Manager/DeviceController.swift
@@ -71,7 +71,7 @@ class DeviceController: UITableViewController, UITextFieldDelegate {
                 self.messageReceivedBackground.tintColor = .zephyr
             }
             if let error = error {
-                self.messageReceived.text = "\(error)"
+                self.messageReceived.text = "\(error.localizedDescription)"
                 self.messageReceivedBackground.tintColor = .systemRed
             }
             self.messageReceived.isHidden = false

--- a/Example/Example/View Controllers/Manager/FileDownloadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FileDownloadViewController.swift
@@ -87,15 +87,11 @@ extension FileDownloadViewController: FileDownloadDelegate {
     
     func downloadDidFail(with error: Error) {
         fileName.textColor = .systemRed
-        if let transferError = error as? FileTransferError {
-            switch transferError {
-            case .mcuMgrErrorCode(.unknown):
-                fileName.text = "File not found"
-            default:
-                fileName.text = "\(error)"
-            }
-        } else {
-            fileName.text = "\(error)"
+        switch error as? FileTransferError {
+        case .mcuMgrErrorCode(.unknown):
+            fileName.text = "File not found"
+        default:
+            fileName.text = "\(error.localizedDescription)"
         }
         fileContent.text = nil
         progress.setProgress(0, animated: true)

--- a/Example/Example/View Controllers/Manager/FileUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FileUploadViewController.swift
@@ -88,7 +88,7 @@ extension FileUploadViewController: FileUploadDelegate {
         actionStart.isHidden = false
         actionSelect.isEnabled = true
         status.textColor = .systemRed
-        status.text = "\(error)"
+        status.text = "\(error.localizedDescription)"
     }
     
     func uploadDidCancel() {

--- a/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
@@ -147,7 +147,7 @@ extension FirmwareUpgradeViewController: FirmwareUpgradeDelegate {
         actionStart.isHidden = false
         actionSelect.isEnabled = true
         status.textColor = .systemRed
-        status.text = "\(error)"
+        status.text = "\(error.localizedDescription)"
     }
     
     func upgradeDidCancel(state: FirmwareUpgradeState) {

--- a/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
@@ -74,7 +74,7 @@ extension FirmwareUploadViewController: ImageUploadDelegate {
         actionStart.isHidden = false
         actionSelect.isEnabled = true
         status.textColor = .systemRed
-        status.text = "\(error)"
+        status.text = "\(error.localizedDescription)"
     }
     
     func uploadDidCancel() {

--- a/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
+++ b/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
@@ -111,7 +111,7 @@ class ImagesViewController: UIViewController , McuMgrViewController{
             readAction.isEnabled = true
             message.textColor = .systemRed
             if let error = error {
-                message.text = "\(error)"
+                message.text = "\(error.localizedDescription)"
             } else {
                 message.text = "Empty response"
             }


### PR DESCRIPTION
As errors were modified to implement `LocalizedError` some time ago, this PR fixes the sample app in a way that the `localizedDescription` is printed instead of default description, which no longer is human-readable.