### PR TITLE
Restoring status label color after error

### DIFF
--- a/Example/Example/View Controllers/Manager/FileUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FileUploadViewController.swift
@@ -35,16 +35,19 @@ class FileUploadViewController: UIViewController, McuMgrViewController {
         actionPause.isHidden = false
         actionCancel.isHidden = false
         actionSelect.isEnabled = false
+        status.textColor = .primary
         status.text = "UPLOADING..."
         _ = fsManager.upload(name: destination.text!, data: fileData!, delegate: self)
     }
     @IBAction func pause(_ sender: UIButton) {
+        status.textColor = .primary
         status.text = "PAUSED"
         actionPause.isHidden = true
         actionResume.isHidden = false
         fsManager.pauseTransfer()
     }
     @IBAction func resume(_ sender: UIButton) {
+        status.textColor = .primary
         status.text = "UPLOADING..."
         actionPause.isHidden = false
         actionResume.isHidden = true

--- a/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
@@ -31,16 +31,19 @@ class FirmwareUploadViewController: UIViewController, McuMgrViewController {
         actionPause.isHidden = false
         actionCancel.isHidden = false
         actionSelect.isEnabled = false
+        status.textColor = .primary
         status.text = "UPLOADING..."
         _ = imageManager.upload(data: imageData!, delegate: self)
     }
     @IBAction func pause(_ sender: UIButton) {
+        status.textColor = .primary
         status.text = "PAUSED"
         actionPause.isHidden = true
         actionResume.isHidden = false
         imageManager.pauseUpload()
     }
     @IBAction func resume(_ sender: UIButton) {
+        status.textColor = .primary
         status.text = "UPLOADING..."
         actionPause.isHidden = false
         actionResume.isHidden = true


### PR DESCRIPTION
Status colors remained red on second attempt after an error.
This PR fixes this issue.