### PR TITLE
Fixed crash on iPad when opening Recent in Files

### DIFF
--- a/Example/Example/View Controllers/Manager/FileDownloadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FileDownloadViewController.swift
@@ -35,6 +35,7 @@ class FileDownloadViewController: UIViewController, McuMgrViewController {
             alert.addAction(UIAlertAction(title: name, style: .default, handler: action))
         }
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.popoverPresentationController?.sourceView = sender
         present(alert, animated: true)
     }
     @IBAction func download(_ sender: Any) {


### PR DESCRIPTION
Popover source view is required on iPads. Lack of it was causing a crash.