### PR TITLE
Add Support for Swift Package Manager

### DIFF
--- a/McuManager.podspec
+++ b/McuManager.podspec
@@ -1,19 +1,19 @@
 Pod::Spec.new do |s|
-  s.name = 'McuManager'
-  s.version = '0.11.1'
-  s.license = { :type => "Apache 2.0", :file => 'LICENSE' }
-  s.summary = 'A mobile management library for devices running Apache Mynewt or Zephyr'
-  s.homepage = 'https://github.com/JuulLabs-OSS/mcumgr-ios'
-  s.authors = { 'Brian Giori' => 'brian.giori@juul.com' }
-  s.source = { :git => 'https://github.com/JuulLabs-OSS/mcumgr-ios.git', :tag => "#{s.version}" }
-  s.swift_versions = ['4.2', '5.0', '5.1', '5.2']
+  s.name = "McuManager"
+  s.version = "0.12.0"
+  s.license = { :type => "Apache 2.0", :file => "LICENSE" }
+  s.summary = "A mobile management library for devices running Apache Mynewt or Zephyr"
+  s.homepage = "https://github.com/JuulLabs-OSS/mcumgr-ios"
+  s.authors = { "Brian Giori" => "brian.giori@juul.com" }
+  s.source = { :git => "https://github.com/JuulLabs-OSS/mcumgr-ios.git", :tag => "#{s.version}" }
+  s.swift_versions = ["4.2", "5.0", "5.1", "5.2"]
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = "9.0"
 
-  s.source_files = 'Source/**/*.{swift, h}'
+  s.source_files = "Source/**/*.{swift, h}"
   s.exclude_files = "Source/*.plist"
 
   s.requires_arc = true
 
-  s.dependency 'SwiftCBOR', '0.4.3'
+  s.dependency "SwiftCBOR", "0.4.3"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -19,9 +19,10 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "McuManager", 
-            dependencies: ["SwiftCBOR"], 
-            path: "Source"
+            name: "McuManager",
+            dependencies: ["SwiftCBOR"],
+            path: "Source",
+            exclude:["Info.plist"]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,10 @@ let package = Package(
         ),
     ],
     targets: [
-        .target(name: "McuManager")
+        .target(
+            name: "McuManager", 
+            dependencies: ["SwiftCBOR"], 
+            path: "Source"
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "McuManager",
+    platforms: [.iOS(.v9)],
+    products: [
+        .library(
+            name: "McuManager",
+            targets: ["McuManager"]
+        ),
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/unrelentingtech/SwiftCBOR.git", 
+            .branch("master")
+        ),
+    ],
+    targets: [
+        .target(name: "McuManager")
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A transport agnostic implementation of the McuManager protocol (aka Newt Manager
 
 ## Install
 
+### Swift Package Manager
+
+In Xcode, go to *File → Swift Packages → Add Package Dependency...* and add `https://github.com/JuulLabs-OSS/mcumgr-ios.git`.
+
 ### CocoaPods
 
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A transport agnostic implementation of the McuManager protocol (aka Newt Manager
 ### CocoaPods
 
 ```
-pod 'McuManager', '~> 0.11.1'
+pod 'McuManager', '~> 0.12.0'
 ```
 
 # Introduction


### PR DESCRIPTION
After merging you should also add a tag `0.12.0` so everything is consistent.

--- 

Resolves #49