### PR TITLE
Added Platform Support for macOS via Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "McuManager",
-    platforms: [.iOS(.v9)],
+    platforms: [.iOS(.v9), .macOS(.v10_13)],
     products: [
         .library(
             name: "McuManager",


### PR DESCRIPTION
On SPM, we list minimum iOS version to be version 9 (2015). However, setting macOS minimum version to 10.11, which was released alongside iOS 9, does not build due to missing API requirements. Therefore, we bumped minimum macOS version to 10.13 (2017), which is the lower macOS version for which we can build McuMgr without any build failures.