### PR TITLE
Fix for 'Using class keyword for protocol inheritance is deprecated' …

### DIFF
--- a/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/Source/Bluetooth/McuMgrBleTransport.swift
@@ -23,7 +23,7 @@ public enum PeripheralState {
     case disconnected
 }
 
-public protocol PeripheralDelegate: class {
+public protocol PeripheralDelegate: AnyObject {
     /// Callback called whenever peripheral state changes.
     func peripheral(_ peripheral: CBPeripheral, didChangeStateTo state: PeripheralState)
 }

--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -679,7 +679,7 @@ public enum FirmwareUpgradeMode {
 //******************************************************************************
 
 /// Callbacks for firmware upgrades started using FirmwareUpgradeManager.
-public protocol FirmwareUpgradeDelegate: class {
+public protocol FirmwareUpgradeDelegate: AnyObject {
     
     /// Called when the upgrade has started.
     ///

--- a/Source/Managers/FileSystemManager.swift
+++ b/Source/Managers/FileSystemManager.swift
@@ -510,7 +510,7 @@ extension FileTransferError: LocalizedError {
 // MARK: File Upload Delegate
 //******************************************************************************
 
-public protocol FileUploadDelegate : class {
+public protocol FileUploadDelegate: AnyObject {
     
     /// Called when a packet of file data has been sent successfully.
     ///
@@ -535,7 +535,7 @@ public protocol FileUploadDelegate : class {
 // MARK: File Download Delegate
 //******************************************************************************
 
-public protocol FileDownloadDelegate : class {
+public protocol FileDownloadDelegate: AnyObject {
     
     /// Called when a packet of file data has been sent successfully.
     ///

--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -438,7 +438,7 @@ extension ImageUploadError: LocalizedError {
 // MARK: Image Upload Delegate
 //******************************************************************************
 
-public protocol ImageUploadDelegate : class {
+public protocol ImageUploadDelegate: AnyObject {
     
     /// Called when a packet of image data has been sent successfully.
     ///

--- a/Source/McuMgrLogDelegate.swift
+++ b/Source/McuMgrLogDelegate.swift
@@ -52,7 +52,7 @@ public enum McuMgrLogCategory: String {
 }
 
 /// The Logger delegate.
-public protocol McuMgrLogDelegate: class {
+public protocol McuMgrLogDelegate: AnyObject {
     
     /// Provides the delegate with content intended to be logged.
     ///

--- a/Source/McuMgrTransport.swift
+++ b/Source/McuMgrTransport.swift
@@ -25,7 +25,7 @@ public enum McuMgrTransportState {
 }
 
 /// The connection state observer protocol.
-public protocol ConnectionObserver: class {
+public protocol ConnectionObserver: AnyObject {
     /// Called whenever the peripheral state changes.
     ///
     /// - parameter transport: the Mcu Mgr transport object.
@@ -83,7 +83,7 @@ extension McuMgrTransportError: LocalizedError {
 
 /// Mcu Mgr transport object. The transport object
 /// should automatically handle connection on first request.
-public protocol McuMgrTransport: class {
+public protocol McuMgrTransport: AnyObject {
     /// Returns the transport scheme.
     ///
     /// - returns: The transport scheme.


### PR DESCRIPTION
…warnings

We've replaced 'class' use with 'AnyObject', which is the preferred keyword in new versions of Swift.