### PR TITLE
Fix for McuMgrImageTlvTrailerEntry's init() reading Data out of bounds

### DIFF
--- a/Source/McuMgrImage.swift
+++ b/Source/McuMgrImage.swift
@@ -158,7 +158,7 @@ public class McuMgrImageTlvTrailerEntry {
     public let size: Int
     
     public init(data: Data, offset: Int) throws {
-        if (offset + McuMgrImageTlvTrailerEntry.MIN_SIZE > data.count) {
+        guard offset + McuMgrImageTlvTrailerEntry.MIN_SIZE < data.count else {
             throw McuMgrImageParseError.insufficientData
         }
         


### PR DESCRIPTION
The previous bounds-check would pass if offset + McuMgrImageTlvTrailerEntry.MIN_SIZE were equal (==) to data.count. However, accessible ranges go from 0...n-1, so accessing the same value in an array as the count of items is an out-of-bounds access.